### PR TITLE
Fixing single_cls function in twoD_dataset.py

### DIFF
--- a/skultrafast/twoD_dataset.py
+++ b/skultrafast/twoD_dataset.py
@@ -179,6 +179,8 @@ class TwoDim:
     "Array with the data, shape must be (t.size, wn_probe.size, wn_pump.size)"
     info: Dict = {}
     "Meta Info"
+    single_cls_result_: Optional[SingleCLSResult] = None
+    "Contains the data from a Single CLS analysis"
     cls_result_: Optional[CLSResult] = None
     "Contains the data from a CLS analysis"
     plot: 'TwoDimPlotter' = attr.Factory(TwoDimPlotter, True)  # typing: Ignore
@@ -413,8 +415,18 @@ class TwoDim:
             r = WLS(y, add_constant(x), weights=1 / yerr**2).fit()
         else:
             r = OLS(y, add_constant(x)).fit()
-        return SingleCLSResult(x + pu[pu_idx].mean(), y, yerr, r.params[0], r, x,
-                               r.predict())
+        
+        ret = SingleCLSResult(pump_wn=x + pu[pu_idx].mean(),
+                        max_pos=y,
+                        max_pos_err=yerr,
+                        slope=r.params[0],
+                        reg_result=r,
+                        recentered_pump_wn=x,
+                        linear_fit=r.predict())
+        
+        self.single_cls_result_ = ret
+
+        return ret
 
     def cls(self, **cls_args) -> CLSResult:
         """Calculates the CLS for all 2d-spectra. The arguments are given


### PR DESCRIPTION
Previously returned a tuple instead of the correct SingleCLSResult class object. Now can use class methods to return values as intended by example code.